### PR TITLE
feat: upgrade Helm version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2025-07-28
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-sparkfabrik-prometheus-stack/compare/4.0.0...5.0.0)
+
+⚠️ **BREAKING CHANGES** ⚠️
+
+The Helm provider version has been updated from 2.x to 3.0. This upgrade introduces significant breaking changes that must be implemented for everything to work correctly.
+
+**Required actions**:
+
+- Update provider configuration: Ensure that the Helm provider version in your project is at least 3.0.
+- Follow the official guide: Consult the official Helm provider [migration guide](https://github.com/hashicorp/terraform-provider-helm/blob/1efcb0eb9fb57b89a5da101040d3dff2fea2e204/docs/guides/v3-upgrade-guide.md) to implement all necessary changes.
+- Test the configuration: Verify that all components work correctly after the upgrade.
+
 ## [4.0.0] - 2024-05-31
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-sparkfabrik-prometheus-stack/compare/3.0.0...4.0.0)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ moved {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.23 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
@@ -128,7 +128,7 @@ moved {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.23 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/main.tf
+++ b/main.tf
@@ -86,15 +86,16 @@ resource "helm_release" "kube_prometheus_stack" {
 
   values = local.kube_prometheus_stack_values
 
-  set_sensitive {
-    name  = "grafana.adminPassword"
-    value = random_password.grafana_admin_password.result
-  }
-
-  set_sensitive {
-    name  = "grafana.adminUser"
-    value = var.grafana_admin_user
-  }
+  set_sensitive = [ 
+    {
+      name  = "grafana.adminPassword"
+      value = random_password.grafana_admin_password.result
+    }, 
+    {
+      name  = "grafana.adminUser"
+      value = var.grafana_admin_user
+    }
+  ]
 
   depends_on = [kubernetes_secret_v1.kube_prometheus_ingress_auth]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Upgraded Helm provider version from 2.0 to 3.0

- Refactored `set_sensitive` blocks to use list syntax

- Updated Terraform configuration for Helm provider compatibility

- Modified kube-prometheus-stack Helm release configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versions.tf</strong><dd><code>Upgrade Helm provider version requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

versions.tf

- Updated Helm provider minimum version from `>= 2.0` to `>= 3.0`


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-prometheus-stack/pull/20/files#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Refactor Helm release sensitive values configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Converted multiple <code>set_sensitive</code> blocks to single list syntax<br> <li> Maintained same Grafana admin password and user configuration<br> <li> Updated syntax for Helm provider v3.0 compatibility


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-prometheus-stack/pull/20/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>