### PR TITLE
Bugfix: Helm resource namespace empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2025-09-02
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-sparkfabrik-prometheus-stack/compare/5.0.0...5.0.1)
+
+- Bugfix: create_namespace = false does not cause an error in resource helm_release.
+
 ## [5.0.0] - 2025-07-28
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-sparkfabrik-prometheus-stack/compare/4.0.0...5.0.0)

--- a/main.tf
+++ b/main.tf
@@ -81,16 +81,16 @@ resource "helm_release" "kube_prometheus_stack" {
   name       = local.app_name_stack
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
-  namespace  = kubernetes_namespace_v1.kube_prometheus_stack_namespace[0].metadata[0].name
+  namespace  = var.create_namespace ? kubernetes_namespace_v1.kube_prometheus_stack_namespace[0].metadata[0].name : var.namespace
   version    = var.prometheus_stack_chart_version
 
   values = local.kube_prometheus_stack_values
 
-  set_sensitive = [ 
+  set_sensitive = [
     {
       name  = "grafana.adminPassword"
       value = random_password.grafana_admin_password.result
-    }, 
+    },
     {
       name  = "grafana.adminUser"
       value = var.grafana_admin_user


### PR DESCRIPTION
### **User description**
When create_namespace is false kubernetes_namespace_v1.kube_prometheus_stack_namespace[0].metadata[0].name :is empty and creation of resource "helm_release" "kube_prometheus_stack" fails because namespace is a empty tuple.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix namespace assignment for helm_release resource

- Add conditional logic to handle create_namespace flag

- Clean up formatting in set_sensitive block

- Prevent empty namespace tuple error


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Fix namespace assignment and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Fix namespace assignment using conditional logic based on <br><code>create_namespace</code> variable<br> <li> Clean up formatting in <code>set_sensitive</code> block by removing trailing spaces


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-prometheus-stack/pull/21/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>